### PR TITLE
Lucho

### DIFF
--- a/src/components/IndicatorSelector.tsx
+++ b/src/components/IndicatorSelector.tsx
@@ -8,7 +8,7 @@ import { getIndicatorsList } from '../services/gibsConfig';
 import '../styles/IndicatorSelector.css';
 
 const IndicatorSelector: React.FC = () => {
-  const { indicator, setIndicator, activateBloomPreset } = useAppStore();
+  const { indicator, setIndicator, activateBloomPreset, bloomModeActive } = useAppStore();
   const indicators = getIndicatorsList();
   
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -40,9 +40,13 @@ const IndicatorSelector: React.FC = () => {
       <button 
         className="bloom-preset-btn"
         onClick={handleBloomPreset}
-        title="Activa capas recomendadas para monitoreo de floración (NDVI + EVI + LST)"
+        title={
+          bloomModeActive
+            ? 'Desactiva el modo floración y vuelve a tu configuración anterior'
+            : 'Activa capas recomendadas para monitoreo de floración (NDVI + LST + Precipitación + Cultivos)'
+        }
       >
-        🌸 Activar Modo Floración
+        {bloomModeActive ? '❌ Desactivar Modo Floración' : '🌸 Activar Modo Floración'}
       </button>
     </div>
   );

--- a/src/components/MultiLayerSelector.tsx
+++ b/src/components/MultiLayerSelector.tsx
@@ -10,7 +10,7 @@ import 'rc-slider/assets/index.css';
 import '../styles/MultiLayerSelector.css';
 
 const MultiLayerSelector: React.FC = () => {
-  const { activeLayers, toggleLayer, setLayerOpacity, activateBloomPreset } = useAppStore();
+  const { activeLayers, toggleLayer, setLayerOpacity, activateBloomPreset, bloomModeActive } = useAppStore();
   const indicators = getIndicatorsList();
   
   const isLayerActive = (layerId: string) => {
@@ -40,8 +40,16 @@ const MultiLayerSelector: React.FC = () => {
     <div className="control-section multi-layer-selector">
       <div className="section-header">
         <label className="control-label">Capas Activas</label>
-        <button onClick={handleBloomPreset} className="bloom-preset-button" title="Activa capas optimizadas para detección de floración">
-          🌸 Modo Floración
+        <button
+          onClick={handleBloomPreset}
+          className="bloom-preset-button"
+          title={
+            bloomModeActive
+              ? 'Desactiva el modo floración y restaura las capas previas'
+              : 'Activa capas optimizadas para detección de floración'
+          }
+        >
+          {bloomModeActive ? '❌ Desactivar Modo Floración' : '🌸 Activar Modo Floración'}
         </button>
       </div>
       

--- a/src/components/MultiLayerSelector.tsx
+++ b/src/components/MultiLayerSelector.tsx
@@ -10,7 +10,7 @@ import 'rc-slider/assets/index.css';
 import '../styles/MultiLayerSelector.css';
 
 const MultiLayerSelector: React.FC = () => {
-  const { activeLayers, toggleLayer, setLayerOpacity, activateBloomPreset, bloomModeActive } = useAppStore();
+  const { activeLayers, toggleLayer, setLayerOpacity } = useAppStore();
   const indicators = getIndicatorsList();
   
   const isLayerActive = (layerId: string) => {
@@ -32,30 +32,13 @@ const MultiLayerSelector: React.FC = () => {
     setLayerOpacity(layerId, opacity / 100);
   };
   
-  const handleBloomPreset = () => {
-    activateBloomPreset();
-  };
-  
   return (
     <div className="control-section multi-layer-selector">
       <div className="section-header">
         <label className="control-label">Capas Activas</label>
-        <button
-          onClick={handleBloomPreset}
-          className="bloom-preset-button"
-          title={
-            bloomModeActive
-              ? 'Desactiva el modo floración y restaura las capas previas'
-              : 'Activa capas optimizadas para detección de floración'
-          }
-        >
-          {bloomModeActive ? '❌ Desactivar Modo Floración' : '🌸 Activar Modo Floración'}
-        </button>
       </div>
       
-      <div className="bloom-preset-info">
-        <small>💡 Modo Floración: Combina NDVI, temperatura superficial, precipitación y cultivos para identificar períodos de floración probable.</small>
-      </div>
+      
       
       <div className="layers-list">
         {indicators.map((indicator) => {


### PR DESCRIPTION
This pull request introduces a new "Modo Floración" (Bloom Mode) feature, allowing users to toggle a preset configuration optimized for bloom monitoring. The implementation includes state management for activating and deactivating the mode, improved UI feedback, and ensures users can revert to their previous configuration. The most important changes are grouped below.

**Feature Implementation: Bloom Mode Toggle**

* Added `bloomModeActive` and `savedStateBeforeBloom` state to the `AppStore` interface and initialized them in the store to track the activation and previous state for bloom mode. [[1]](diffhunk://#diff-3ea8be5bd95ed3d553404284f4d8828c6501fb766a2ee6ab2751d08cd4a420ecR29-R36) [[2]](diffhunk://#diff-3ea8be5bd95ed3d553404284f4d8828c6501fb766a2ee6ab2751d08cd4a420ecR74-R75)
* Refactored the `activateBloomPreset` action to support toggling: when activating, it saves the current state and applies the bloom preset; when deactivating, it restores the previous state or simply disables bloom mode if no snapshot exists. [[1]](diffhunk://#diff-3ea8be5bd95ed3d553404284f4d8828c6501fb766a2ee6ab2751d08cd4a420ecL290-R340) [[2]](diffhunk://#diff-3ea8be5bd95ed3d553404284f4d8828c6501fb766a2ee6ab2751d08cd4a420ecR368-R369)

**UI Updates for Bloom Mode**

* Updated `IndicatorSelector` to show dynamic button text and tooltip, reflecting whether bloom mode is active or not. [[1]](diffhunk://#diff-c3612d1ff6f0578938bf312054dc8194bfb1fbc910cd34a34467a2414adca6d4L11-R11) [[2]](diffhunk://#diff-c3612d1ff6f0578938bf312054dc8194bfb1fbc910cd34a34467a2414adca6d4L43-R49)
* Removed bloom mode button and info from `MultiLayerSelector`, centralizing the toggle in `IndicatorSelector` for a cleaner interface. [[1]](diffhunk://#diff-469c3a8659088692f3ed8b1440f36895572a024f4fdddf4399751646400f7a6fL13-R13) [[2]](diffhunk://#diff-469c3a8659088692f3ed8b1440f36895572a024f4fdddf4399751646400f7a6fL35-R41)